### PR TITLE
Single-line OpenFL module imports

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 
-import sys
-import os
-import inspect
-from os.path import dirname
+#Import OpenFL modules from relative parent directory
+from ..OpenFL import FLP, Printer
 
-# Add parent directory to sys.path so we find OpenFL.
-sys.path.insert(0, dirname(dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))))
+#import sys
+#import os
+#import inspect
+#from os.path import dirname
 
+## Add parent directory to sys.path so we find OpenFL.
+#sys.path.insert(0, dirname(dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))))
 
-from OpenFL import FLP
-from OpenFL import Printer
+#from OpenFL import FLP
+#from OpenFL import Printer


### PR DESCRIPTION
Tested as best as I could on my system with:
```
modulename = "FLP"
if 'FLP' not in sys.modules:
print 'You have not imported the {} module'.format(modulename)
```
but I don't own a Form printer. I believe this is a simpler way to import FLP and Printer though.