### PR TITLE
Use io.BytesIO rather than io.StringIO since we are working with bytearrays now.

### DIFF
--- a/OpenFL/FLP.py
+++ b/OpenFL/FLP.py
@@ -578,8 +578,8 @@ class Packets(list):
     @staticmethod
     def fromstring(string):
         """Load all the packets in a string buffer."""
-        from io import StringIO
-        return fromfile(StringIO(string))
+        from io import BytesIO
+        return fromfile(BytesIO(string))
 
     @staticmethod
     def fromfile(fileHandle):


### PR DESCRIPTION
Tested on a Form 1+ just now: Master throws an exception when the StringIO is constructed from a bytearray, but BytesIO works (and BytesIO can be constructed from a string too).