### PR TITLE
Actually call self.moverate_Hz().

### DIFF
--- a/OpenFL/FLP.py
+++ b/OpenFL/FLP.py
@@ -240,7 +240,7 @@ class XYMoveClockRate(LaserCommand):
         return XYMoveClockRate.DEFAULT_DATA
 
     def _reprContents(self):
-        return '{} Hz'.format(self.moverate_Hz)
+        return '{} Hz'.format(self.moverate_Hz())
 
 class MotorMoveCommand(MotorCommand):
     """


### PR DESCRIPTION
Makes repr look like ` <XYMoveClockRate(60000 Hz) at 0x107c88f90>` rather than like `<XYMoveClockRate(<function moverate_Hz at 0x104de72a8> Hz) at 0x104dd5e90>`.